### PR TITLE
docs: Explain the usage of the `--port` CL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ your latest changes. Bedecked ships with a live reload server to support
 interactive presentation development. Try `bedecked --server my_prez.md` or view
 `bedecked help server` for more information.
 
+The default port `bedecked --server` uses is `9090`. You can set a different
+port by adding the `--port <portNumber>` option:
+
+```
+bedecked --port 80 --server my_prez.md
+```
+
 ## Testing
 
 Test and lint with `grunt`.


### PR DESCRIPTION
Add an explanation on how to use the --port option when using bedecked on the
command line

Closes #21 