### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:onbuild
+
+ENTRYPOINT [ "bin/bedecked" ]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,52 @@ bedecked --port 80 --server my_prez.md
 Note that the `server` and `port` options are only available with the bedecked
 cli.
 
+## Docker support
+
+Bedecked features Docker support. A Dockerfile is provided and there is a [Bedecked Docker image](https://hub.docker.com/r/jtrussell/bedecked/) available on Docker Hub [built automatically](https://docs.docker.com/docker-hub/builds/) from source on each commit.
+
+You can develop, build and run Bedecked using Docker. You can also package and run Bedecked presentations as self-contained Docker images.
+
+No installation other than Docker is necessary in any case.
+
+### Develop & Build
+
+A Dockerfile is included to allow you to develop and build Bedecked using standard Docker workflow.
+
+#### Build from current source dir:
+
+```docker build -t bedecked .```
+
+#### Run built image:
+
+```docker run --rm -it -p 9090:9090 bedecked your_prez.md --server [options...]```
+
+### Run a presentation
+
+You can run your local Bedecked presentations without installing anything (other than Docker):
+
+```
+$ docker run --rm -it -p 9090:9090 -v [your_host_prez_dir]:/presentation/ jtrussell/bedecked /presentation/your_prez_file.md --server [other options...]
+```
+
+Using ```--rm``` instead of ```-d``` makes the container to not go to background and to be deleted after stop. Should stop by ```CTRL+C```'ing it, but doesn't work because of #28. Use ```docker stop``` from another terminal, instead.
+
+### Package
+
+Just create a file named ```Dockerfile``` in your presentation's source directory. Use the following as example and customize as needed:
+
+```
+FROM jtrussell/bedecked
+
+# Add presentation file(s)
+COPY index.md /presentation/
+
+# Set options for Bedecked executable
+CMD [ "/presentation/index.md", "--server", "--opt-slide-number", "true", "--opt-slide-number", "true", "--opt-mouse-wheel", "true" ]
+```
+
+Build and run the resulting image using standard Docker workflow. See Docker docs for more information.
+
 ## Testing
 
 Test and lint with `grunt`.


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official NodeJS image, 'onbuild' tag. More info at https://hub.docker.com/_/node/

'Onbuild' image tag takes care of NodeJS standard build steps (see link). I'm not very familiar with building.

Build image from local source:

```
$ docker build -t bedecked .
```

Run:

```
$ docker run --rm -it -p 9090:9090 -v [your_host_prez_dir]:/presentation/ bedecked /presentation/prez.md --server [other options...]
```
You should be able to browse it at localhost:9090 .

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 9090:9090 -v [your_host_prez_dir]:/presentation/ pataquets/bedecked-build /presentation/prez.md --server [other options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it, but doesn't work because of #28. Use ```docker stop``` from another terminal, instead.

Using the resulting image, you will be able to build your own Docker images based on it with the presentation built-in.
Here it is an example Dockerfile (using my public image to make it work). Requires a suitable index.md file in the same dir:
```
FROM pataquets/bedecked-build

COPY index.md .

CMD [ "index.md", "--server", "--opt-slide-number", "true", "--opt-slide-number", "true", "--opt-mouse-wheel", "true" ]
```

Build it:
```
docker build bedecked-test .
```
Run it:
```
docker run --rm -it -p 9090:9090 bedecked-test
```

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.